### PR TITLE
Update 2-dependabot-alerts.md

### DIFF
--- a/.github/steps/2-dependabot-alerts.md
+++ b/.github/steps/2-dependabot-alerts.md
@@ -26,9 +26,9 @@ Let's enable Dependabot alerts on our repository!
 1. Navigate to the `Settings` tab.
 1. Click `Code security and analysis`.
 1. Click `Enable` Dependabot alerts (**Wait about 60 seconds and then click the `Security` tab at the top of the repository**).
-1. Review each of the four `Dependabot` alerts under the `Vulnerability alerts` section.
+1. Review each of the `Dependabot` alerts under the `Vulnerability alerts` section.
 
-Dependabot has alerted us of four vulnerabilities that need to be updated from the dependencies that we are using. Dependabot helps us address these vulnerabilities by creating pull requests for each one as we select and review the alert.
+Dependabot has alerted us of vulnerabilities that need to be updated from the dependencies that we are using. Dependabot helps us address these vulnerabilities by creating pull requests for each one as we select and review the alert.
 
 Let's see how this would work by using Dependabot to create a pull request for one of the alerts!
 


### PR DESCRIPTION
Removal of a hard-coded number ("four") for the amount vulnerabilities discovered by dependabot.

### Summary

This request increases the accuracy and reduces confusion about possible vulnerabilities discovered by dependabot by removing the hard-coded number ("four"), considering all packages within may be actively maintained and patched during and after time of writing. The amount of vulnerabilities produced by Axios, follow-redirects, json5, and minimist discovered by dependabot have been counted as 5 at time of writing.
### Changes

This pull request serves no other purpose outside of revision for accuracy and grammar according to the content-style guide.

### Task list
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
