### PR TITLE
check for axios 1.6.0 instead of 0.21.2

### DIFF
--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -55,18 +55,18 @@ jobs:
           fetch-depth: 0 # Let's get all the branches.
 
       # Verify the PR added the dependabot changes.
-      - name: Check package for axios version 0.21.2
+      - name: Check package for axios version 1.6.0
         uses: skills/action-check-file@v1
         with:
           file: "code/src/AttendeeSite/package.json"
-          search: "0.21.2"
+          search: "1.6.0"
 
       # Verify the PR added the dependabot changes.
-      - name: Check package-lock for axios version 0.21.2
+      - name: Check package-lock for axios version 1.6.0
         uses: skills/action-check-file@v1
         with:
           file: "code/src/AttendeeSite/package-lock.json"
-          search: "0.21.2"
+          search: "1.6.0"
 
       # In README.md, switch step 3 for step 4.
       - name: Update to step 4


### PR DESCRIPTION
### Summary
Lab doesn't transition to Step 4 because Dependabot upgrades to a different version of axios package

![image](https://github.com/skills/secure-repository-supply-chain/assets/10464497/413b863b-3494-4717-9845-622ff795b71a)

### Changes
Check for axios 1.6.0 instead of 0.21.2

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
