### PR TITLE
Update axios version check to match dependabot from 1.6.0 to 0.28.0

### DIFF
--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -55,18 +55,18 @@ jobs:
           fetch-depth: 0 # Let's get all the branches.
 
       # Verify the PR added the dependabot changes.
-      - name: Check package for axios version 1.6.0
+      - name: Check package for axios version 0.28.0
         uses: skills/action-check-file@v1
         with:
           file: "code/src/AttendeeSite/package.json"
-          search: "1.6.0"
+          search: "0.28.0"
 
       # Verify the PR added the dependabot changes.
-      - name: Check package-lock for axios version 1.6.0
+      - name: Check package-lock for axios version 0.28.0
         uses: skills/action-check-file@v1
         with:
           file: "code/src/AttendeeSite/package-lock.json"
-          search: "1.6.0"
+          search: "0.28.0"
 
       # In README.md, switch step 3 for step 4.
       - name: Update to step 4


### PR DESCRIPTION
### Summary
Step 3 of the workflow fails due to Dependabot reporting the vulnerability resolution as updating to version 0.28.0 


### Changes
Updated the version check in Step 3 workflow file to reflect the current state of Dependabot security update PR. The validation value has been hard coded for now, it may be a better idea long term to use a range or regex pattern possibly.

Closes:
#19 

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
