### PR TITLE
fix GitHub action step 0's trigger

### DIFF
--- a/.github/workflows/0-welcome.yml
+++ b/.github/workflows/0-welcome.yml
@@ -6,8 +6,10 @@ name: Step 0, Welcome
 # This will run every time we create push a commit to `main`.
 # Reference: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
-  create:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 # Reference: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:


### PR DESCRIPTION
### Summary
Step zero is not triggered when creating the repository new repository with **Start course** button, so execise do not start because README isn't updated.


### Changes
I have change _on_ value in 0-welcome.yml to trigger this workflow every time  anyone push to main

Closes:
#25 

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
