### PR TITLE
fix: Incorrect url for copy exercise

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In this course, you will explore:
 
 Simply copy the exercise to your account, then give your favorite Octocat (Mona) **about 20 seconds** to prepare the first lesson, then **refresh the page**.
 
-[![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=arilivigni&template_name=secure-repository-supply-chain&owner=%40me&name=skills-secure-repository-supply-chain&description=Exercise:+Secure+your+Repository+Supply+Chain&visibility=public)
+[![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=skills&template_name=secure-repository-supply-chain&owner=%40me&name=skills-secure-repository-supply-chain&description=Exercise:+Secure+your+Repository+Supply+Chain&visibility=public)
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>


### PR DESCRIPTION
This pull request updates the `README.md` file to correct the URL for the "Copy Exercise" badge, ensuring it points to the correct repository template.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R43): Updated the `Copy Exercise` badge link to use `skills` as the template owner instead of `arilivigni`.