### PR TITLE
fix: update condition to skip first run for check step work jobs

### DIFF
--- a/.github/workflows/1-dependency-graph.yml
+++ b/.github/workflows/1-dependency-graph.yml
@@ -21,13 +21,15 @@ jobs:
   find_exercise:
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
+    if: |
+      github.run_number != 1
 
   check_step_work:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
     if: |
-      !github.event.repository.is_template && github.run_number != 1
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/1-dependency-graph.yml
+++ b/.github/workflows/1-dependency-graph.yml
@@ -26,7 +26,8 @@ jobs:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
-    if: !github.event.repository.is_template
+    if: |
+      !github.event.repository.is_template && github.run_number != 1
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/2-dependabot-alerts.yml
+++ b/.github/workflows/2-dependabot-alerts.yml
@@ -21,13 +21,15 @@ jobs:
   find_exercise:
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
+    if: |
+      github.run_number != 1
 
   check_step_work:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
     if: |
-      !github.event.repository.is_template && github.run_number != 1
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/2-dependabot-alerts.yml
+++ b/.github/workflows/2-dependabot-alerts.yml
@@ -26,7 +26,8 @@ jobs:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
-    if: !github.event.repository.is_template
+    if: |
+      !github.event.repository.is_template && github.run_number != 1
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -21,13 +21,15 @@ jobs:
   find_exercise:
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
+    if: |
+      github.run_number != 1
 
   check_step_work:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
     if: |
-      !github.event.repository.is_template && github.run_number != 1
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -26,7 +26,8 @@ jobs:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
-    if: !github.event.repository.is_template
+    if: |
+      !github.event.repository.is_template && github.run_number != 1
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -26,7 +26,8 @@ jobs:
     name: Check step work
     needs: find_exercise
     runs-on: ubuntu-latest
-    if: !github.event.repository.is_template
+    if: |
+      !github.event.repository.is_template && github.run_number != 1
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -29,7 +29,7 @@ jobs:
     needs: find_exercise
     runs-on: ubuntu-latest
     if: |
-      github.event.repository.is_template == false
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 
@@ -78,7 +78,8 @@ jobs:
     name: Post review content
     needs: [find_exercise, check_step_work]
     runs-on: ubuntu-latest
-    if: !github.event.repository.is_template
+    if: |
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -21,13 +21,15 @@ jobs:
   find_exercise:
     name: Find Exercise Issue
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.3.0
+    if: |
+      github.run_number != 1
 
   check_step_work:
     name: Check step work
     needs: find_exercise
     runs-on: ubuntu-latest
     if: |
-      !github.event.repository.is_template && github.run_number != 1
+      !github.event.repository.is_template
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 

--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -8,7 +8,7 @@ on:
       - ".github/dependabot.yml"
 
 permissions:
-  contents: write
+  contents: read
   actions: write
   issues: write
 

--- a/.github/workflows/4-dependabot-versions.yml
+++ b/.github/workflows/4-dependabot-versions.yml
@@ -8,7 +8,7 @@ on:
       - ".github/dependabot.yml"
 
 permissions:
-  contents: read
+  contents: write
   actions: write
   issues: write
 
@@ -29,7 +29,7 @@ jobs:
     needs: find_exercise
     runs-on: ubuntu-latest
     if: |
-      !github.event.repository.is_template
+      github.event.repository.is_template == false
     env:
       ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 


### PR DESCRIPTION
This pull request updates the conditional logic in multiple GitHub Actions workflows to prevent certain jobs from running on the first workflow run of a repository. The affected workflows include dependency graph, Dependabot alerts, Dependabot security, and Dependabot versions.