### PR TITLE
fix: Revert "Bump skills/action-text-variables from 2 to 3 (#81)"

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build comment - add step content
         id: build-comment
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: "${{ env.STEP_1_FILE }}"
           template-vars: |

--- a/.github/workflows/1-dependency-graph.yml
+++ b/.github/workflows/1-dependency-graph.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build message - step finished
         id: build-message-step-finish
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           template-vars: |
@@ -110,7 +110,7 @@ jobs:
 
       - name: Build comment - add step content
         id: build-comment
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: "${{ env.STEP_2_FILE }}"
           template-vars: |

--- a/.github/workflows/2-dependabot-alerts.yml
+++ b/.github/workflows/2-dependabot-alerts.yml
@@ -111,7 +111,7 @@ jobs:
   
       - name: Build message - step finished
         id: build-message-step-finish
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           template-vars: |
@@ -145,7 +145,7 @@ jobs:
 
       - name: Build comment - add step content
         id: build-comment
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: "${{ env.STEP_3_FILE }}"
           template-vars: |

--- a/.github/workflows/3-dependabot-security.yml
+++ b/.github/workflows/3-dependabot-security.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build message - step finished
         id: build-message-step-finish
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: exercise-toolkit/markdown-templates/step-feedback/step-finished-prepare-next-step.md
           template-vars: |
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build comment - add step content
         id: build-comment
-        uses: skills/action-text-variables@v3
+        uses: skills/action-text-variables@v2
         with:
           template-file: "${{ env.STEP_4_FILE }}"
           template-vars: |


### PR DESCRIPTION
This reverts commit ce4ec00ce4d41f663bc312ca67aae4a67b0fc487.

This is not a simple version bump. v3 is a major update and introduces breaking changes that require using updated templates and verifying the format in the learning step files.
